### PR TITLE
make attester duties work with compulsory index parameter, and fix slot/epoch mix

### DIFF
--- a/tests/get/v1/validator/duties/attester/42/200_0.json
+++ b/tests/get/v1/validator/duties/attester/42/200_0.json
@@ -1,5 +1,6 @@
 {
   "method": "GET",
-  "route": "/eth/v1/validator/duties/attester/42",
-  "awaitSlot": 42
+  "route": "/eth/v1/validator/duties/attester/3",
+  "awaitSlot": 42,
+  "queryParams": {"index": "1"}
 }

--- a/tests/get/v1/validator/duties/proposer/42/200_0.json
+++ b/tests/get/v1/validator/duties/proposer/42/200_0.json
@@ -1,5 +1,5 @@
 {
   "method": "GET",
-  "route": "/eth/v1/validator/duties/proposer/42",
+  "route": "/eth/v1/validator/duties/proposer/3",
   "awaitSlot": 42
 }


### PR DESCRIPTION
While testing attester duties, I had to update this test with the compulsory query parameter, feeding upstream for others.