### PR TITLE
add required query parameters for attestation_data

### DIFF
--- a/tests/get/v1/validator/attestation_data/200_0.json
+++ b/tests/get/v1/validator/attestation_data/200_0.json
@@ -1,4 +1,5 @@
 {
   "method": "GET",
-  "route": "/eth/v1/validator/attestation_data"
+  "route": "/eth/v1/validator/attestation_data",
+  "queryParams": { "slot": "42", "committee_index": "1"}
 }


### PR DESCRIPTION
attestation_data has required query parameters `slot`, and `committee_index` - added so that test would pass.