### PR TITLE
Removing deprecated GHA set-output command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.ref }}
       - name: get version
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       - name: build (all platforms)
         uses: ./.github/actions/build
       - name: create release


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

GitHub plans to fully disable this on 31st May 2023. Starting 1st June 2023 workflows using `save-state` or `set-output` commands via stdout will fail with an error.